### PR TITLE
Fix issue with post interval timing

### DIFF
--- a/models/student.rb
+++ b/models/student.rb
@@ -11,9 +11,11 @@ class Student
   # Returns Integer EPOCH time.
   def last_submission_at 
     if last_submission.nil? || last_submission_was_not_today?
+      binding.pry
       return "first_of_day"
     else
       formatter = TimeFormatter.new(time_since_last_checkin)
+      binding.pry
       return formatter.time_as_hms
     end
   end
@@ -39,5 +41,6 @@ class Student
   # Checks to see if last student submission was NOT today.
   def last_submission_was_not_today?
     Time.at(last_checkin_at).utc.day != Time.now.day
+    binding.pry
   end
 end

--- a/models/student.rb
+++ b/models/student.rb
@@ -11,11 +11,9 @@ class Student
   # Returns Integer EPOCH time.
   def last_submission_at 
     if last_submission.nil? || last_submission_was_not_today?
-      binding.pry
       return "first_of_day"
     else
       formatter = TimeFormatter.new(time_since_last_checkin)
-      binding.pry
       return formatter.time_as_hms
     end
   end
@@ -41,6 +39,5 @@ class Student
   # Checks to see if last student submission was NOT today.
   def last_submission_was_not_today?
     Time.at(last_checkin_at).utc.day != Time.now.day
-    binding.pry
   end
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -3,5 +3,4 @@
 <div id="dailyFeed">
 </div>
 
-<!-- temporary cookie reset -->
 <a href="/reset" style="color: black">Logout & Reset User</a>


### PR DESCRIPTION
After the SQL switch-over, a bug has come up that no longer finds if a student's post is the first of the day. This bug seems completely contained in the submissions class. A function that should be returning true (and looks it does in pry) is not. Will debug and fix.