### PR TITLE
Fixed issue with variable name

### DIFF
--- a/models/post.rb
+++ b/models/post.rb
@@ -26,7 +26,7 @@ class Post
 	end
 
 	def stressLevel
-		@post["stressLevel"]
+		@post["stresslevel"]
 	end
 
 	def submission


### PR DESCRIPTION
Discovered when calling column names from a SQL table, use all lower case regardless of how it was inputted.